### PR TITLE
Pre-initialize sqlite tables

### DIFF
--- a/xmltotabular/xmlcollectiontotabular.py
+++ b/xmltotabular/xmlcollectiontotabular.py
@@ -97,6 +97,11 @@ class XmlCollectionToTabular:
         self.db = SqliteDB(db_conn)
 
         for tablename, fieldnames in self.get_fieldnames().items():
+            if tablename in self.db.table_names():
+                for fieldname in fieldnames:
+                    if fieldname not in self.db[tablename].columns_dict:
+                        self.db[tablename].add_column(fieldname, str)
+                continue
             params = {"column_order": fieldnames}
             if "id" in fieldnames:
                 params["pk"] = "id"

--- a/xmltotabular/xmlcollectiontotabular.py
+++ b/xmltotabular/xmlcollectiontotabular.py
@@ -96,6 +96,14 @@ class XmlCollectionToTabular:
         db_conn.execute("pragma journal_mode=memory;")
         self.db = SqliteDB(db_conn)
 
+        for tablename, fieldnames in self.get_fieldnames().items():
+            params = {"column_order": fieldnames}
+            if "id" in fieldnames:
+                params["pk"] = "id"
+            self.db[tablename].create(
+                {fieldname: str for fieldname in fieldnames}, **params
+            )
+
     def convert(self):
         if not self.xml_files:
             self.logger.warning(colored("No input files to process!", "red"))


### PR DESCRIPTION
To work around #21, ensure all sqlite tables are pre-initialized with all necessary columns before any inserts are done.

Closes #21.